### PR TITLE
fix: TMR mixer output tracking incomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Fresh tracks your products using a batch system - each harvest or production run
 
 ## Changelog
 
+### 0.7.1.0 (Alpha - 2026-01-27)
+- Fixed TMR mixer output tracking - FORAGE amount now correctly tracks all ingredients
+
 ### 0.7.0.0 (Alpha - 2026-01-24)
 - Added support for ALL fillTypes - basegame, DLCs, and maps/mods now configurable
 - Improved Settings sorting - products with types appear first for easier navigation

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>Ritter</author>
-    <version>0.7.0.0</version>
+    <version>0.7.1.0</version>
     <title>
         <en>Fresh</en>
     </title>
@@ -34,6 +34,9 @@ Notes:
 Documentation: https://github.com/rittermod/FS25_Fresh
 
 Changelog:
+
+0.7.1.0 (Alpha):
+- Fixed TMR mixer output tracking - FORAGE amount now correctly tracks all ingredients
 
 0.7.0.0 (Alpha):
 - Added support for ALL fillTypes - basegame, DLCs, and maps/mods now configurable

--- a/scripts/core/RmFreshManager.lua
+++ b/scripts/core/RmFreshManager.lua
@@ -1046,10 +1046,11 @@ function RmFreshManager:onFillChanged(containerId, fillUnitIndex, delta, fillTyp
     local container = self.containers[containerId]
     if container and container.fillTypeIndex and container.fillTypeIndex ~= fillType then
         if delta > 0 then
-            -- Fill type changed with new fill: clear old batches, update fillType
-            Log:debug("FILL_TYPE_CHANGE: container=%s old=%d new=%d (clearing %d batches)",
+            -- Fill type changed with new fill: update fillType, preserve batches
+            -- (FS25 empties old type via FIFO before loading new type in normal trailers;
+            -- MixerWagon transitions type without emptying, so batches must be preserved)
+            Log:debug("FILL_TYPE_CHANGE: container=%s old=%d new=%d (preserving %d batches)",
                 containerId, container.fillTypeIndex, fillType, #(container.batches or {}))
-            container.batches = {}
             container.fillTypeIndex = fillType
             -- Also update identityMatch for display and save/load
             if container.identityMatch and container.identityMatch.storage then


### PR DESCRIPTION
Previously, loading ingredients into a TMR mixer caused batch clearing on each fill type change (SILAGE → FORAGE_MIXING → FORAGE), resulting in Fresh tracking only a fraction of the actual FORAGE amount.

Fixes #5