### PR TITLE
fix: preserve pig feed age when deposited into pigsty

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Fresh tracks your products using a batch system - each harvest or production run
 
 ### 0.7.1.0 (Alpha - 2026-01-27)
 - Fixed TMR mixer output tracking - FORAGE amount now correctly tracks all ingredients
+- Fixed pig feed (PIGFOOD) losing age when deposited into pigsty - mixture ingredients now preserve source age
 
 ### 0.7.0.0 (Alpha - 2026-01-24)
 - Added support for ALL fillTypes - basegame, DLCs, and maps/mods now configurable

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -37,6 +37,7 @@ Changelog:
 
 0.7.1.0 (Alpha):
 - Fixed TMR mixer output tracking - FORAGE amount now correctly tracks all ingredients
+- Fixed pig feed (PIGFOOD) losing age when deposited into pigsty
 
 0.7.0.0 (Alpha):
 - Added support for ALL fillTypes - basegame, DLCs, and maps/mods now configurable

--- a/scripts/adapters/RmVehicleAdapter.lua
+++ b/scripts/adapters/RmVehicleAdapter.lua
@@ -163,6 +163,10 @@ end
 
 function RmVehicleAdapter.registerOverwrittenFunctions(vehicleType)
     SpecializationUtil.registerOverwrittenFunction(vehicleType, "showInfo", RmVehicleAdapter.showInfo)
+    -- Transfer age preservation: must use registerOverwrittenFunction (not late-bound
+    -- Utils.overwrittenFunction) because late hooks don't reach already-loaded vehicles.
+    -- Safe no-op for vehicle types without Dischargeable (skips if function absent).
+    SpecializationUtil.registerOverwrittenFunction(vehicleType, "dischargeToObject", RmTransferCoordinator.dischargeToObject)
 end
 
 -- =============================================================================


### PR DESCRIPTION
Mixture ingredients (MAIZE, WHEAT, etc.) now retain the source PIGFOOD age during husbandry food decomposition.

Fixes #6