### PR TITLE
fix: rescan world for untracked containers on settings change

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Fresh tracks your products using a batch system - each harvest or production run
 ### 0.7.1.0 (Alpha - 2026-01-27)
 - Fixed TMR mixer output tracking - FORAGE amount now correctly tracks all ingredients
 - Fixed pig feed (PIGFOOD) losing age when deposited into pigsty - mixture ingredients now preserve source age
+- Fixed containers not starting to age after enabling expiration for a previously disabled product
 
 ### 0.7.0.0 (Alpha - 2026-01-24)
 - Added support for ALL fillTypes - basegame, DLCs, and maps/mods now configurable

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -38,6 +38,7 @@ Changelog:
 0.7.1.0 (Alpha):
 - Fixed TMR mixer output tracking - FORAGE amount now correctly tracks all ingredients
 - Fixed pig feed (PIGFOOD) losing age when deposited into pigsty
+- Fixed containers not aging after enabling expiration for a previously disabled product
 
 0.7.0.0 (Alpha):
 - Added support for ALL fillTypes - basegame, DLCs, and maps/mods now configurable

--- a/scripts/adapters/RmPlaceableAdapter.lua
+++ b/scripts/adapters/RmPlaceableAdapter.lua
@@ -656,6 +656,29 @@ function RmPlaceableAdapter.registerStorageContents(placeable, spec, storage)
     return registered
 end
 
+--- Rescan all placeables for newly-perishable storage fillTypes (RIT-139)
+--- Called when settings change makes a fillType perishable
+---@return number count Number of new containers registered
+function RmPlaceableAdapter.rescanForPerishables()
+    if not g_currentMission or not g_currentMission.placeableSystem then return 0 end
+
+    Log:trace(">>> RmPlaceableAdapter.rescanForPerishables()")
+    local count = 0
+    for _, placeable in ipairs(g_currentMission.placeableSystem.placeables) do
+        local spec = placeable[RmPlaceableAdapter.SPEC_TABLE_NAME]
+        if spec and spec.containerIds then
+            local storages = RmPlaceableAdapter.discoverStorages(placeable)
+            for _, storageInfo in ipairs(storages) do
+                count = count + RmPlaceableAdapter.registerStorageContents(
+                    placeable, spec, storageInfo.storage
+                )
+            end
+        end
+    end
+    Log:trace("<<< RmPlaceableAdapter.rescanForPerishables = %d", count)
+    return count
+end
+
 --- Defer registration until uniqueId is available (for purchased placeables)
 --- Pattern from VehicleAdapter with timeout protection
 ---@param placeable table Placeable entity

--- a/scripts/core/RmFreshSettings.lua
+++ b/scripts/core/RmFreshSettings.lua
@@ -303,6 +303,11 @@ function RmFreshSettings:onSettingsChanged()
         broadcast = true
     end
 
+    -- Rescan world for newly-perishable containers (RIT-139)
+    if g_server and RmFreshManager then
+        RmFreshManager:rescanForNewPerishables()
+    end
+
     local globalCount = self:tableCount(self.userOverrides.global)
     local ftCount = self:tableCount(self.userOverrides.fillTypes)
     Log:debug("SETTINGS_CHANGED: %d global, %d fillTypes (broadcast=%s)",


### PR DESCRIPTION
When a fillType is changed from "do not expire" to perishable, all five adapters now scan their FS25 entity collections and register any previously-skipped containers with age=0.

Fixes #8